### PR TITLE
fix: set custom user name instead of default jovyan

### DIFF
--- a/jupyterhub/jupyterhub_config.py
+++ b/jupyterhub/jupyterhub_config.py
@@ -47,6 +47,10 @@ c.JupyterHub.hub_ip = os.environ['HUB_IP']
 notebook_dir = os.environ.get('DOCKER_NOTEBOOK_DIR') or '/home/user'
 c.DockerSpawner.notebook_dir = notebook_dir
 c.DockerSpawner.volumes = {'jupyterhub-user-{username}': notebook_dir}
+c.DockerSpawner.environment = {
+    'NB_USER': '${JUPYTERHUB_USER}', 
+    'CHOWN_HOME': 'yes'}
+c.DockerSpawner.extra_create_kwargs = {"user": "root"}
 
 # Other stuff
 c.Spawner.cpu_limit = 1


### PR DESCRIPTION
We need to set
- environment `NB_USER` to the desired user name,
- environment `CHOWN_HOME` to "yes",
- an extra argument `--user=root`.  
 
See [Jupyter Docker stacks documentation](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/common.html#docker-options) for the details.

With the `DockerSpawner`, we need the following config:

```Python
c.DockerSpawner.environment = {
    'NB_USER': '${JUPYTERHUB_USER}', 
    'CHOWN_HOME': 'yes'}
c.DockerSpawner.extra_create_kwargs = {"user": "root"}
```

